### PR TITLE
Handling PackageNotFoundError

### DIFF
--- a/tg-bot/tg_bot/__main__.py
+++ b/tg-bot/tg_bot/__main__.py
@@ -3,7 +3,7 @@ import os.path
 import telebot
 
 from tg_bot.config import load_cfg
-from tg_bot.doc_parser import is_file_court_decision
+from tg_bot.doc_parser import is_tg_file_court_decision
 from tg_bot.exceptions import BotException
 
 cfg = load_cfg()
@@ -49,7 +49,7 @@ def handle_docs(message):
         return
 
     try:
-        if not is_file_court_decision(message.document.file_id, bot, cfg):
+        if not is_tg_file_court_decision(message.document.file_id, bot, cfg):
             bot.send_message(
                 message.chat.id,
                 f"Похоже, что присланный документ не является судебным решением.",


### PR DESCRIPTION
В облаке наш телеграм-бот падает с ошибкой "PackageNotFoundError" (см. stack trace ниже). Не понимаю в чем именнодело, но добавил обработку этой ошибки в бот. 

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/nik/dev/annulment_court_decision/tg-bot/tg_bot/__main__.py", line 66, in <module>
    bot.polling(none_stop=True, interval=0)
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/telebot/__init__.py", line 1047, in polling
    self.__threaded_polling(non_stop=non_stop, interval=interval, timeout=timeout, long_polling_timeout=long_polling_timeout,
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/telebot/__init__.py", line 1122, in __threaded_polling
    raise e
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/telebot/__init__.py", line 1078, in __threaded_polling
    self.worker_pool.raise_exceptions()
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/telebot/util.py", line 154, in raise_exceptions
    raise self.exception_info
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/telebot/util.py", line 98, in run
    task(*args, **kwargs)
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/telebot/__init__.py", line 6086, in _run_middlewares_and_handler
    result = handler['function'](message)
  File "/home/nik/dev/annulment_court_decision/tg-bot/tg_bot/__main__.py", line 52, in handle_docs
    if not is_file_court_decision(message.document.file_id, bot, cfg):
  File "/home/nik/dev/annulment_court_decision/tg-bot/tg_bot/doc_parser.py", line 31, in is_file_court_decision
    ms_doc = docx.Document(tmp_file)
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/docx/api.py", line 25, in Document
    document_part = Package.open(docx).main_document_part
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/docx/opc/package.py", line 128, in open
    pkg_reader = PackageReader.from_file(pkg_file)
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/docx/opc/pkgreader.py", line 32, in from_file
    phys_reader = PhysPkgReader(pkg_file)
  File "/home/nik/dev/annulment_court_decision/tg-bot/venv/lib/python3.10/site-packages/docx/opc/phys_pkg.py", line 30, in __new__
    raise PackageNotFoundError(
docx.opc.exceptions.PackageNotFoundError: Package not found at 'ms_docs/BQACAgIAAxkBAAMRY35p2le0RbzWHA4H6Zvj80f0ojAAAu8fAALSk_lLqYh3RsSIx8orBA.doc'
(tg-bot) nik@tg-bot:~/dev/annulment_court_decision/tg-bot$ python -m tg_bot
```